### PR TITLE
Naive implementation of sparse Top-K attention approximation from FlexGen.

### DIFF
--- a/attention_utils.py
+++ b/attention_utils.py
@@ -37,6 +37,7 @@ def scaled_dot_product_attention(
 
     top_k_idxs = None
     if attn_top_k > 0:
+        # For each head, we extract the top_k keys based on average attn_weight across queries.
         _, top_k_idxs = attn_weight.mean(dim=-2).topk(min(S, attn_top_k), dim=-1)
         value = value.gather(-2, top_k_idxs.unsqueeze(-1).expand(-1, -1, -1, value.shape[-1]))
         attn_weight = attn_weight.gather(-1, top_k_idxs.unsqueeze(-2).expand(-1, -1, attn_weight.shape[-2], -1))


### PR DESCRIPTION
Adds basic support for the attention sparsity method from [`FlexGen`](https://arxiv.org/abs/2303.06865).

See **Sparse Attention, Page 7**:

```
We present one simple Top-K sparse approximation. After computing the attention matrices, for each query, we calculate the indices of its Top-K tokens from the K cache. We then simply drop the other tokens and only load a subset of the V cache according to the indices.
```

## A few implementation notes
- I implemented this by computing the `topk` indices and then gathering them.  Their cache management is implemented differently yet ours is always in GPU memory.
- If `attn_top_k > 0`, we call spda with `return_att=True` so that we run our naive spda implementation, which we can modify easily.  We do not actually need to return the attention.


